### PR TITLE
Add possibility to provide custom properties.

### DIFF
--- a/src/demo/body/Example.jsx
+++ b/src/demo/body/Example.jsx
@@ -11,12 +11,13 @@ import Source from './Source';
 import Form from '../../Form';
 import SimpleRating from './custom-rating';
 
-const CustomComponent = ({ onChange, formData }) => {
+const CustomComponent = ( { onChange, formData, label }) => {
   const [data, setData] = useState(formData.customComponent || '');
+  const customLabel = label || '';
   return (
       <TextField
         id='standard-basic'
-        label='Custom Text'
+        label={customLabel}
         value={data}
         onChange={(e) => setData(e.target.value)}
         onBlur={(e) => onChange(e.target.value)}
@@ -52,9 +53,10 @@ const FormComponent = React.memo(
 			onUpload={onUpload}
 			onChange={onFormChanged}
 			components={{
-			  customComponent: ({ onChange }) => (
-					<CustomComponent onChange={onChange} formData={formData} />
-			  ),
+			  customComponent: ({onChange, label}) => {
+			    return (
+					<CustomComponent onChange={onChange} formData={formData} label={label}  />
+			  )},
 			  customRating: ({ onChange }) => (
 					<CustomRating onChange={onChange} formData={formData} />
 			  ),

--- a/src/demo/examples/simple/ui-schema.json
+++ b/src/demo/examples/simple/ui-schema.json
@@ -16,6 +16,9 @@
 			"useLocaleString": "nl"
 		}
 	},
+	"customComponent": {
+		"custom:label": "Custom label"
+	},
 	"age": {
 		"ui:widget": "updown",
 		"ui:title": "Age of person",

--- a/src/fields/configure/get-component.props.spec.js
+++ b/src/fields/configure/get-component.props.spec.js
@@ -182,6 +182,13 @@ describe('getComponentProps', () => {
     expect(componentProps).to.haveOwnProperty('myprop');
     expect(componentProps.myprop).to.equal('boo');
   });
+  it('passes custom:* properties', () => {
+    const schema = { 'title': 'First name', customComponent: 'customComponent' };
+    const uiSchema = { 'custom:myprop': 'boo' };
+    const componentProps = getComponentProps({ schema, uiSchema });
+    expect(componentProps).to.haveOwnProperty('myprop');
+    expect(componentProps.myprop).to.equal('boo');
+  });
   describe('onChange callback', () => {
     it('is called with event target value', () => {
       // prepare

--- a/src/fields/configure/get-mui-props.js
+++ b/src/fields/configure/get-mui-props.js
@@ -1,4 +1,0 @@
-import mapKeys from 'lodash/mapKeys';
-import pickBy from 'lodash/pickBy';
-
-export default props => mapKeys(pickBy(props, (v, k) => k.startsWith('mui:')), (v, k) => k.substring(4));

--- a/src/fields/configure/get-props.js
+++ b/src/fields/configure/get-props.js
@@ -1,0 +1,4 @@
+import mapKeys from 'lodash/mapKeys';
+import pickBy from 'lodash/pickBy';
+
+export default (props, propsKey = 'mui') => mapKeys(pickBy(props, (v, k) => k.startsWith(propsKey + ':')), (v, k) => k.substring(propsKey.length + 1));


### PR DESCRIPTION
When using custom components, sometimes it is necessary to send custom properties from the ui schema.

For this I introduced the new `custom:[propertyName]` format in the ui-schema and I modified the code to apply those properties directy on the custom element.